### PR TITLE
Deprecate python-opentelemetry-walkthrough

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
+=====================================================================================================================
+This is example is now deprecated.  For up to date examples, see https://github.com/lightstep/opentelemetry-examples.
+=====================================================================================================================
+
 =========================================
 MicroDonuts: An OpenTelemetry Walkthrough
 =========================================
-
 
 Welcome to MicroDonuts! This is a sample application and OpenTelemetry
 walkthrough, written in Python.


### PR DESCRIPTION
This example repo has gotten out of date; deprecate it in favor of the single streamlined examples repo.  I'll archive the repo as soon as this PR is merged.